### PR TITLE
Tweak code to be more idiomatic Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,59 +180,49 @@ impl TagLibTag {
         }
     }
 
-    pub fn set_title(self: &Self, title: &String) -> StringWriteError { 
+    pub fn set_title(self: &Self, title: &str) -> StringWriteError {
         unsafe {
-            let title_ptr : *const c_char = match CString::new(title.as_str()) {
-                Ok(cstr) => cstr.as_ptr(), 
-                Err(e) => return Err(e)
-            };
-            taglib_tag_set_title(self.tag, title_ptr);
+            CString::new(title).map(|cstr| {
+                let title_ptr = cstr.as_ptr();
+                taglib_tag_set_title(self.tag, title_ptr);
+            })
         }
-        Ok(())
     }
 
-    pub fn set_artist(self: &Self, artist: &String) -> StringWriteError { 
+    pub fn set_artist(self: &Self, artist: &str) -> StringWriteError {
         unsafe {
-            let artist_ptr : *const c_char = match CString::new(artist.as_str()) {
-                Ok(cstr) => cstr.as_ptr(), 
-                Err(e) => return Err(e)
-            };
-            taglib_tag_set_artist(self.tag, artist_ptr);
+            CString::new(artist).map(|cstr| {
+                let artist_ptr = cstr.as_ptr();
+                taglib_tag_set_artist(self.tag, artist_ptr);
+            })
         }
-        Ok(())
     }
 
-    pub fn set_album(self: &Self, album: &String) -> StringWriteError { 
+    pub fn set_album(self: &Self, album: &str) -> StringWriteError {
         unsafe {
-            let album_ptr : *const c_char = match CString::new(album.as_str()) {
-                Ok(cstr) => cstr.as_ptr(), 
-                Err(e) => return Err(e)
-            };
-            taglib_tag_set_album(self.tag, album_ptr);
+            CString::new(album).map(|cstr| {
+                let album_ptr = cstr.as_ptr();
+                taglib_tag_set_album(self.tag, album_ptr);
+            })
         }
-        Ok(())
     }
 
-    pub fn set_comment(self: &Self, comment: &String) -> StringWriteError { 
+    pub fn set_comment(self: &Self, comment: &str) -> StringWriteError {
         unsafe {
-            let comment_ptr : *const c_char = match CString::new(comment.as_str()) {
-                Ok(cstr) => cstr.as_ptr(), 
-                Err(e) => return Err(e)
-            };
-            taglib_tag_set_comment(self.tag, comment_ptr);
+            CString::new(comment).map(|cstr| {
+                let comment_ptr = cstr.as_ptr();
+                taglib_tag_set_comment(self.tag, comment_ptr);
+            })
         }
-        Ok(())
     }
 
-    pub fn set_genre(self: &Self, genre: &String) -> StringWriteError { 
+    pub fn set_genre(self: &Self, genre: &str) -> StringWriteError {
         unsafe {
-            let genre_ptr : *const c_char = match CString::new(genre.as_str()) {
-                Ok(cstr) => cstr.as_ptr(), 
-                Err(e) => return Err(e)
-            };
-            taglib_tag_set_genre(self.tag, genre_ptr);
+            CString::new(genre).map(|cstr| {
+                let genre_ptr = cstr.as_ptr();
+                taglib_tag_set_genre(self.tag, genre_ptr);
+            })
         }
-        Ok(())
     }
 
     pub fn set_year(self: &Self, year: u32) -> () { 


### PR DESCRIPTION
Hey!

Just a couple of changes in here to get a few of the methods in line with idiomatic Rust.

I wasn't entirely sure of the best way to accept a path and turn it into a `CString`, see the discussion here https://stackoverflow.com/questions/38948669/whats-the-most-direct-way-to-convert-a-path-to-a-c-char

I also reworked the setter methods to accept an `&str` instead of an `&String`, and work with the one `Result`, so you only return once, and don't have to chuck a `Ok(())` at the end

FYI you usually don't want to use `&String`, as discussed here https://users.rust-lang.org/t/whats-the-difference-between-string-and-str/10177